### PR TITLE
Agregar node_modules al .gitignore para excluir dependencias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+# Dependencias de Node.js
+node_modules/


### PR DESCRIPTION
Agrego node_modules al .gitignore para evitar subir dependencias de Node.js al repositorio, ya que estas se deben instalar localmente con `npm install`.

**💡 Propósito educativo:** Este cambio sirve como ejemplo para practicar:
- Flujo de Pull Requests en GitHub
- Exclusión de archivos/directorios innecesarios en repositorios
- Buenas prácticas de gestión de dependencias

**📝 Nota:** Esto se realiza a modo de ejemplo práctico, no porque el proyecto vaya a usar Node.js. Puedes aprobar o rechazar el pull request para practicar ambos flujos.

🔒 **Sugerencia de mejora en el flujo:**
Noté que como colaborador puedo realizar el merge directamente en main. En proyectos reales, lo recomendable es que solo el dueño o revisores autorizados lo hagan.

Se puede configurar en Settings → Branches → Add branch ruleset→Ruleset Name(poner nombre descriptivo al conjunto de reglas) → en Target Branches → Add target →Include by pattern →Branch naming pattern (poner  la rama a proteger (main))


en rules
activando: 


✅ Require pull request reviews before merging 

✅ poner en required aprovads en 1


✅ dejar habilitado las predeterminadas  Restrict deletions y Block force pushes.

por ultimo botón Crear
